### PR TITLE
Preserve API group in resource names

### DIFF
--- a/src/OpenShiftGrapher/OpenShiftGrapher.py
+++ b/src/OpenShiftGrapher/OpenShiftGrapher.py
@@ -332,9 +332,7 @@ def main():
                                             if apiGroup == "":
                                                 resourceName = resource
                                             else:
-                                                resourceName = apiGroup
-                                                resourceName = ":"
-                                                resourceName = resource
+                                                resourceName = f"{apiGroup}:{resource}"
 
                                             ressourceNode = Node("Resource", name=resourceName, uid="Resource_"+role.metadata.namespace+"_"+resourceName)
                                             ressourceNode.__primarylabel__ = "Resource"
@@ -466,9 +464,7 @@ def main():
                                             if apiGroup == "":
                                                 resourceName = resource
                                             else:
-                                                resourceName = apiGroup
-                                                resourceName = ":"
-                                                resourceName = resource
+                                                resourceName = f"{apiGroup}:{resource}"
 
                                             ressourceNode = Node("Resource", name=resourceName, uid="Resource_cluster"+"_"+resourceName)
                                             ressourceNode.__primarylabel__ = "Resource"


### PR DESCRIPTION
## Summary
- ensure resource name keeps its API group when building graph

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97424c33883259a28f5801a196bda