### PR TITLE
Fix service account name comparison in test mock

### DIFF
--- a/tests/testOpenShiftGrapher.py
+++ b/tests/testOpenShiftGrapher.py
@@ -45,7 +45,7 @@ class OpenShiftGrapherTests(unittest.TestCase):
         mock_service_accounts = MagicMock(
             get=MagicMock(side_effect=lambda name=None, namespace=None: (
                 serviceaccount1 if name == "serviceaccount1" and namespace == "namespace1" else
-                serviceaccount2 if name == "namespace2" and namespace == "namespace2" else
+                serviceaccount2 if name == "serviceaccount2" and namespace == "namespace2" else
                 MagicMock(items=[serviceaccount1, serviceaccount2])  # Return list when name is not provided
             ))
         )


### PR DESCRIPTION
## Summary
- Ensure the mock service account lookup checks for `serviceaccount2` instead of `namespace2`

## Testing
- `pytest tests/testOpenShiftGrapher.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b9745b6d3c83259a38afcff65368e3