### PR TITLE
Add ConstraintTemplate support via directory loader

### DIFF
--- a/src/OpenShiftGrapher/OpenShiftGrapher.py
+++ b/src/OpenShiftGrapher/OpenShiftGrapher.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from argparse import RawTextHelpFormatter
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Sequence
 
 import urllib3
@@ -44,6 +45,7 @@ FETCH_MESSAGES = {
     "route": "Fetching Routes",
     "pod": "Fetching Pods",
     "configmap": "Fetching ConfigMaps",
+    "constraint_template": "Loading ConstraintTemplates from directory",
     "validating_webhook_configuration": "Fetching ValidatingWebhookConfigurations",
     "mutating_webhook_configuration": "Fetching MutatingWebhookConfiguration",
     "cluster_policy": "Fetching ClusterPolicy",
@@ -114,7 +116,62 @@ def _json_default(obj: Any) -> Any:
         return obj.to_dict()
     if isinstance(obj, set):
         return sorted(obj)
+    if isinstance(obj, SimpleNamespace):
+        return {key: _json_default(value) for key, value in vars(obj).items()}
     return str(obj)
+
+
+def _to_namespace(obj: Any) -> Any:
+    """Recursively convert *obj* into ``SimpleNamespace`` instances."""
+
+    if isinstance(obj, dict):
+        return SimpleNamespace(**{key: _to_namespace(value) for key, value in obj.items()})
+    if isinstance(obj, list):
+        return [_to_namespace(item) for item in obj]
+    return obj
+
+
+def _namespace_to_dict(obj: Any) -> Any:
+    """Convert ``SimpleNamespace`` hierarchies back into plain Python objects."""
+
+    if isinstance(obj, SimpleNamespace):
+        return {key: _namespace_to_dict(value) for key, value in vars(obj).items()}
+    if isinstance(obj, list):
+        return [_namespace_to_dict(item) for item in obj]
+    if isinstance(obj, dict):
+        return {key: _namespace_to_dict(value) for key, value in obj.items()}
+    return obj
+
+
+def load_constraint_templates_from_dir(directory: Path | None) -> SimpleNamespace:
+    """Load ConstraintTemplate JSON files from *directory*.
+
+    The return value mimics the Kubernetes client list object with an ``items`` attribute
+    so that it can be consumed by the existing collector logic.
+    """
+
+    if directory is None:
+        result = SimpleNamespace(items=[])
+        setattr(result, "_source_directory", None)
+        return result
+
+    if not directory.exists():
+        raise FileNotFoundError(f"ConstraintTemplates directory '{directory}' does not exist")
+
+    if not directory.is_dir():
+        raise NotADirectoryError(f"ConstraintTemplates path '{directory}' is not a directory")
+
+    constraint_templates = []
+    for file_path in sorted(directory.glob("*.json")):
+        with file_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        namespace_obj = _to_namespace(payload)
+        setattr(namespace_obj, "_source_path", str(file_path))
+        constraint_templates.append(namespace_obj)
+
+    result = SimpleNamespace(items=constraint_templates)
+    setattr(result, "_source_directory", str(directory))
+    return result
 
 
 def backup_resource_data(
@@ -130,7 +187,7 @@ def backup_resource_data(
         serialisable_content = (
             resource_content.to_dict()
             if hasattr(resource_content, "to_dict") and callable(resource_content.to_dict)
-            else resource_content
+            else _namespace_to_dict(resource_content)
         )
         with resource_path.open("w", encoding="utf-8") as resource_file:
             json.dump(serialisable_content, resource_file, indent=2, default=_json_default)
@@ -162,7 +219,7 @@ def main() -> None:
         default="all",
         help='list of collectors. Possible values: all, project, scc, securitycontextconstraints, sa, role, '
              'clusterrole, rolebinding, clusterrolebinding, route, pod, kyverno, '
-             'validatingwebhookconfiguration, mutatingwebhookconfiguration, clusterpolicies'
+             'constrainttemplate, validatingwebhookconfiguration, mutatingwebhookconfiguration, clusterpolicies'
     )
     parser.add_argument('-u', '--userNeo4j', default=DEFAULT_NEO4J_USER, help='neo4j database user.')
     parser.add_argument('-p', '--passwordNeo4j', default=DEFAULT_NEO4J_PASSWORD, help='neo4j database password.')
@@ -172,6 +229,12 @@ def main() -> None:
         '--backupResources',
         action='store_true',
         help='Backup fetched resources into files named after the database.',
+    )
+    parser.add_argument(
+        '--constraintTemplatesDir',
+        type=Path,
+        default=None,
+        help='Directory containing ConstraintTemplate JSON exports to import into the graph.',
     )
 
     args = parser.parse_args()
@@ -185,6 +248,7 @@ def main() -> None:
     proxy_url = args.proxyUrl
     database_name = args.databaseName
     backup_resources_enabled = args.backupResources
+    constraint_templates_dir = args.constraintTemplatesDir
 
     release = True
 
@@ -294,6 +358,13 @@ def main() -> None:
         dyn_client, api_key, host_api, proxy_url, 'v1', 'ConfigMap'
     )
 
+    print(FETCH_MESSAGES["constraint_template"])
+    try:
+        constraint_template_list = load_constraint_templates_from_dir(constraint_templates_dir)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        print(f"[-] {exc}")
+        raise SystemExit(1) from exc
+
     print(FETCH_MESSAGES["validating_webhook_configuration"])
     validating_webhook_configuration_list, dyn_client, api_key = fetch_resource_with_refresh(
         dyn_client, api_key, host_api, proxy_url, 'admissionregistration.k8s.io/v1', 'ValidatingWebhookConfiguration'
@@ -326,6 +397,7 @@ def main() -> None:
             "route": route_list,
             "pod": pod_list,
             "configmap": configmap_list,
+            "constraint_template": constraint_template_list,
             "validating_webhook_configuration": validating_webhook_configuration_list,
             "mutating_webhook_configuration": mutating_webhook_configuration_list,
             "cluster_policy": cluster_policy_list,
@@ -351,6 +423,7 @@ def main() -> None:
         pod_list=pod_list,
         kyverno_logs=kyverno_logs,
         configmap_list=configmap_list,
+        constraintTemplate_list=constraint_template_list,
         validatingWebhookConfiguration_list=validating_webhook_configuration_list,
         mutatingWebhookConfiguration_list=mutating_webhook_configuration_list,
         clusterPolicy_list=cluster_policy_list,

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -84,6 +84,7 @@ def test_collector_context_exposes_lookup_tables():
         kyverno_logs=None,
         configmap_list=None,
         constraintTemplate_list=None,
+        k8sValuesPattern_list=None,
         validatingWebhookConfiguration_list=None,
         mutatingWebhookConfiguration_list=None,
         clusterPolicy_list=None,

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -82,6 +82,7 @@ def test_collector_context_exposes_lookup_tables():
         pod_list=None,
         kyverno_logs=None,
         configmap_list=None,
+        constraintTemplate_list=None,
         validatingWebhookConfiguration_list=None,
         mutatingWebhookConfiguration_list=None,
         clusterPolicy_list=None,

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,9 +1,13 @@
 from types import SimpleNamespace
 
+import OpenShiftGrapher.collectors as collectors_module
+
 from OpenShiftGrapher.collectors import (
     CollectorContext,
     LookupTables,
     _build_lookup_tables,
+    _collect_k8svaluespattern,
+    _collect_keyword_values,
     _iterate_constrainttemplate_rego_sources,
     _should_collect,
 )
@@ -100,6 +104,33 @@ def test_collector_context_exposes_lookup_tables():
     assert context.group_by_name["team"] == "group"
 
 
+def test_collect_keyword_values_extracts_nested_exclusions():
+    additional_match = SimpleNamespace(
+        clusterExclusionsName="namespace-denied-name-pattern",
+        accountSelector=SimpleNamespace(
+            excludedAccounts=[
+                "system:admin",
+                "system:serviceaccount:openshift:router",
+            ],
+            excludedClusterRoles=["cluster-admin"],
+        ),
+        namespaceSelector=SimpleNamespace(
+            excludedNamespaces=["openshift-monitoring"],
+        ),
+        otherField="should-ignore",
+    )
+
+    result = _collect_keyword_values(additional_match, ("exclude", "exclusion"))
+
+    assert result["clusterExclusionsName"] == ["namespace-denied-name-pattern"]
+    assert result["excludedAccounts"] == [
+        "system:admin",
+        "system:serviceaccount:openshift:router",
+    ]
+    assert result["excludedClusterRoles"] == ["cluster-admin"]
+    assert result["excludedNamespaces"] == ["openshift-monitoring"]
+
+
 def test_iterate_constrainttemplate_rego_sources_handles_code_blocks_and_libs():
     target = SimpleNamespace(
         rego=None,
@@ -131,3 +162,171 @@ def test_iterate_constrainttemplate_rego_sources_handles_code_blocks_and_libs():
         "package secondary\nallow { true }",
         "package lib.helpers\nallow { false }",
     ]
+
+
+def test_collect_k8svaluespattern_records_exclusions_and_protections(monkeypatch):
+    class DummyBar:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def next(self):
+            pass
+
+    class DummyNode(dict):
+        def __init__(self, label, **properties):  # pylint: disable=unused-argument
+            super().__init__(properties)
+
+    class FakeMatch:
+        def count(self):
+            return 0
+
+    class FakeNodes:
+        def match(self, _label):
+            return FakeMatch()
+
+    class FakeTx:
+        def __init__(self, store):
+            self.store = store
+
+        def merge(self, node):
+            self.store.append(node)
+
+    class FakeGraph:
+        def __init__(self):
+            self.created_nodes = []
+            self.nodes = FakeNodes()
+
+        def begin(self):
+            return FakeTx(self.created_nodes)
+
+        def commit(self, _tx):
+            pass
+
+    monkeypatch.setattr(collectors_module, "Bar", DummyBar)
+    monkeypatch.setattr(collectors_module, "Node", DummyNode)
+
+    graph = FakeGraph()
+    lookups = LookupTables(
+        project_by_name={},
+        serviceaccount_by_ns_name={},
+        security_context_constraints_by_name={},
+        role_by_ns_name={},
+        clusterrole_by_name={},
+        user_by_name={},
+        group_by_name={},
+    )
+
+    values_pattern = SimpleNamespace(
+        metadata=SimpleNamespace(name="namespace-denied-name-pattern", uid="uid-123"),
+        spec=SimpleNamespace(
+            enforcementAction="scoped",
+            scopedEnforcementActions=[
+                SimpleNamespace(
+                    action="deny",
+                    enforcementPoints=[
+                        SimpleNamespace(name="validation.gatekeeper.sh"),
+                    ],
+                )
+            ],
+            match=SimpleNamespace(
+                kinds=[
+                    SimpleNamespace(apiGroups=[""], kinds=["Namespace"]),
+                    SimpleNamespace(apiGroups=["apps"], kinds=["Deployment"]),
+                ]
+            ),
+            parameters=SimpleNamespace(
+                violationDocumentation=SimpleNamespace(
+                    linkToDocumentation="https://toto.atlassian.net/wiki/x/uvrPew",
+                ),
+                additionalMatch=SimpleNamespace(
+                    clusterExclusionsName="namespace-denied-name-pattern",
+                    accountSelector=SimpleNamespace(
+                        excludedAccounts=[
+                            "system:admin",
+                            "system:serviceaccount:openshift:router",
+                        ],
+                        excludedClusterRoles=["cluster-admin"],
+                    ),
+                    namespaceSelector=SimpleNamespace(
+                        excludedNamespaces=["openshift-monitoring"],
+                    ),
+                ),
+                valuesPatterns=[
+                    SimpleNamespace(
+                        parent="metadata",
+                        patterns=[
+                            SimpleNamespace(
+                                field="name",
+                                deny=True,
+                                globs=["openshift*", "stackrox", "kube-*"],
+                            ),
+                            SimpleNamespace(
+                                field="name",
+                                deny=True,
+                                values=["system"],
+                            ),
+                        ],
+                    )
+                ],
+            ),
+        ),
+        _source_path="/tmp/namespace-denied-name-pattern.yaml",
+    )
+
+    context = CollectorContext(
+        graph=graph,
+        collector={"k8svaluespattern"},
+        release=True,
+        oauth_list=None,
+        identity_list=None,
+        project_list=None,
+        serviceAccount_list=None,
+        security_context_constraints_list=None,
+        role_list=None,
+        clusterrole_list=None,
+        user_list=None,
+        group_list=None,
+        roleBinding_list=None,
+        clusterRoleBinding_list=None,
+        route_list=None,
+        pod_list=None,
+        kyverno_logs=None,
+        configmap_list=None,
+        constraintTemplate_list=None,
+        k8sValuesPattern_list=SimpleNamespace(
+            items=[values_pattern],
+            _source_directory="/manifests",
+        ),
+        validatingWebhookConfiguration_list=None,
+        mutatingWebhookConfiguration_list=None,
+        clusterPolicy_list=None,
+        lookups=lookups,
+    )
+
+    _collect_k8svaluespattern(context)
+
+    assert len(graph.created_nodes) == 1
+    node = graph.created_nodes[0]
+
+    assert node["excludedSummary"] == (
+        "clusterExclusionsName: namespace-denied-name-pattern; "
+        "excludedAccounts: system:admin, system:serviceaccount:openshift:router; "
+        "excludedClusterRoles: cluster-admin; excludedNamespaces: openshift-monitoring"
+    )
+    assert node["excludedAccounts"] == "system:admin, system:serviceaccount:openshift:router"
+    assert node["excludedClusterRoles"] == "cluster-admin"
+    assert node["excludedNamespaces"] == "openshift-monitoring"
+    assert node["clusterExclusionsName"] == "namespace-denied-name-pattern"
+    assert node["protectedGlobs"] == "kube-*, openshift*, stackrox"
+    assert node["protectedValues"] == "system"
+    assert node["protectedSummary"] == (
+        "globs: kube-*, openshift*, stackrox; values: system"
+    )
+    assert node["matchKinds"] == "Namespace, apps/Deployment"
+    assert "🚫 2 deny patterns" in node["risk"]

--- a/tests/test_openshiftgrapher.py
+++ b/tests/test_openshiftgrapher.py
@@ -220,7 +220,15 @@ def test_load_constraint_templates_from_dir(tmp_path, monkeypatch):
             "targets": [
                 {
                     "target": "admission.k8s.gatekeeper.sh",
-                    "rego": "package owners\nviolation[{}] { true }",
+                    "code": [
+                        {
+                            "engine": "Rego",
+                            "source": {
+                                "version": "v1",
+                                "rego": "package owners\nviolation[{}] { true }",
+                            },
+                        }
+                    ],
                 }
             ],
         },
@@ -245,6 +253,10 @@ def test_load_constraint_templates_from_dir(tmp_path, monkeypatch):
     template = result.items[0]
     assert template.metadata.name == "ns-must-have-owner"
     assert template.spec.targets[0].target == "admission.k8s.gatekeeper.sh"
+    assert (
+        template.spec.targets[0].code[0].source.rego
+        == "package owners\nviolation[{}] { true }"
+    )
     assert template.status.byPod[0].errors[0].message == "rego parse error"
     assert template._source_path == str(template_path)
     assert result._source_directory == str(tmp_path)

--- a/tests/test_openshiftgrapher.py
+++ b/tests/test_openshiftgrapher.py
@@ -200,7 +200,13 @@ def test_fetch_resource_propagates_other_errors(monkeypatch, patched_client):
         )
 
 
-def test_load_constraint_templates_from_dir(tmp_path):
+def test_load_constraint_templates_from_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        osg,
+        "yaml",
+        types.SimpleNamespace(safe_load_all=lambda data: [json.loads(data)]),
+    )
+
     template_content = {
         "apiVersion": "templates.gatekeeper.sh/v1beta1",
         "kind": "ConstraintTemplate",
@@ -230,7 +236,7 @@ def test_load_constraint_templates_from_dir(tmp_path):
             ],
         },
     }
-    template_path = tmp_path / "template.json"
+    template_path = tmp_path / "template.yaml"
     template_path.write_text(json.dumps(template_content), encoding="utf-8")
 
     result = osg.load_constraint_templates_from_dir(tmp_path)


### PR DESCRIPTION
## Summary
- add a loader that converts ConstraintTemplate JSON exports into namespaces and expose it via a new CLI flag
- store ConstraintTemplate resources in Neo4j with key metadata, package details, and error nodes
- update tests to cover the new loader and collector context wiring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0922333e48325be3f8ba2ace5ceb1